### PR TITLE
Fix exporting dbr files

### DIFF
--- a/GEMS3K/datach_api.cpp
+++ b/GEMS3K/datach_api.cpp
@@ -51,24 +51,25 @@ std::string check_TP(const DATACH* CSD, double TK, double P)
 
     if( CSD->mLook == 1 )
     {
-        for(long int  jj=0; jj<CSD->nPp; jj++)
-            if( (fabs( P - CSD->Pval[jj] ) < CSD->Ptol ) && ( fabs( TK - CSD->TKval[jj] ) < CSD->Ttol ) )
-            {
+        for(long int  jj=0; jj<CSD->nPp; jj++) {
+            if( (fabs( P - CSD->Pval[jj] ) < CSD->Ptol ) && ( fabs( TK - CSD->TKval[jj] ) < CSD->Ttol ) ) {
                 return error_msg;
             }
-        Error( "check_TP: ", std::string("Temperature ")+std::to_string(TK)+
-               " and pressure "+std::to_string(P)+" out of range");
-        //return false;
+        }
+        error_msg += "Current TK=" + std::to_string(TK);
+        error_msg += " and P=" + std::to_string(P);
+        error_msg += " are beyond the T, P pairs list (no interpolation mode)";
+
+        //Error( "check_TP: ", std::string("Temperature ")+std::to_string(TK)+
+        //       " and pressure "+std::to_string(P)+" out of range");
+        return error_msg;
     }
-    else
-    {
-        if( TK <= CSD->TKval[0] - CSD->Ttol )
-        { 				// Lower boundary of T interpolation interval
+    else  {
+        if( TK <= CSD->TKval[0] - CSD->Ttol )  {	// Lower boundary of T interpolation interval
             okT = false;
             T_ = CSD->TKval[0] - CSD->Ttol;
         }
-        if( TK >= CSD->TKval[CSD->nTp-1] + CSD->Ttol )
-        {
+        if( TK >= CSD->TKval[CSD->nTp-1] + CSD->Ttol )  {
             okT = false;
             T_ = CSD->TKval[CSD->nTp-1] + CSD->Ttol;
         }
@@ -78,13 +79,11 @@ std::string check_TP(const DATACH* CSD, double TK, double P)
             error_msg += std::to_string(T_);
         }
 
-        if( P <= CSD->Pval[0] - CSD->Ptol )
-        {
+        if( P <= CSD->Pval[0] - CSD->Ptol ) {
             okP = false;
             P_ = CSD->Pval[0] - CSD->Ptol;
         }
-        if( P >= CSD->Pval[CSD->nPp-1] + CSD->Ptol )
-        {
+        if( P >= CSD->Pval[CSD->nPp-1] + CSD->Ptol ) {
             okP = false;
             P_ = CSD->Pval[CSD->nPp-1] + CSD->Ptol;
         }
@@ -96,6 +95,41 @@ std::string check_TP(const DATACH* CSD, double TK, double P)
         return error_msg;
     }
     return error_msg;
+}
+
+bool change_TP(const DATACH* CSD, double& TK, double& P)
+{
+    bool ok = false;
+
+    if( CSD->mLook==1 ) {
+        for(long int jj=0; jj<CSD->nPp; jj++) {
+            if( (fabs(P-CSD->Pval[jj]) < CSD->Ptol) && (fabs(TK-CSD->TKval[jj]) < CSD->Ttol) ) {
+                return ok;
+            }
+        }
+        TK = CSD->TKval[0];
+        P = CSD->Pval[0];
+        return true;
+    }
+    else  {
+        if( TK <= CSD->TKval[0]-CSD->Ttol )  {	// Lower boundary of T interpolation interval
+            ok = true;
+            TK = CSD->TKval[0];
+        }
+        else if( TK >= CSD->TKval[CSD->nTp-1]+CSD->Ttol )  {
+            ok= true;
+            TK = CSD->TKval[CSD->nTp-1];
+        }
+        if( P <= CSD->Pval[0]-CSD->Ptol ) {
+            ok = true;
+            P = CSD->Pval[0];
+        }
+        else if( P >= CSD->Pval[CSD->nPp-1]+CSD->Ptol ) {
+            ok = true;
+            P = CSD->Pval[CSD->nPp-1];
+        }
+    }
+    return ok;
 }
 
 long int check_grid_T(const DATACH* CSD, double TK)

--- a/GEMS3K/datach_api.h
+++ b/GEMS3K/datach_api.h
@@ -139,6 +139,9 @@ long int gridTP(const DATACH* pCSD);
 /// Checks if given temperature TK and pressure P fit within the interpolation
 /// intervals of the DATACH lookup arrays (returns empty message) or not (returns error message)
 std::string check_TP(const DATACH* CSD, double TK, double P);
+/// Checks if the given temperature TK and pressure P fit within the interpolation intervals of the
+/// DATACH lookup arrays (returns false) or not (changes TK and P to limits and returns true)
+bool change_TP(const DATACH* CSD, double& TK, double& P);
 /// Tests TK as a grid point for the interpolation of thermodynamic data.
 /// \return index in the lookup grid array or -1  if it is not a grid point
 long int check_grid_T(const DATACH* CSD, double TK);

--- a/GEMS3K/gems3k_version.h
+++ b/GEMS3K/gems3k_version.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #define GEMS3K_VERSION "4.5.5"
-#define GEMS3K_VERSION_HASH "3baee5b"
+#define GEMS3K_VERSION_HASH "9f5d032"
 #define GEMS3K_GIT_BRANCH "master"
 #define GEMS3K_ChemicalFun "0.1.13"
 #define GEMS3K_ThermoFun "0.5.4"

--- a/GEMS3K/ipm_chemical3.cpp
+++ b/GEMS3K/ipm_chemical3.cpp
@@ -879,7 +879,7 @@ void TMultiBase::SolModCreate( long int jb, long int jmb, long int jsb, long int
             delete phSolMod[k];
 
      phSolMod[k] = mySM; // set up new pointer for the solution model
-    if(TSolMod::solmod_logger->should_log(spdlog::level::debug)) {
+    if(mySM && TSolMod::solmod_logger->should_log(spdlog::level::debug)) {
      phSolMod[k]->to_json_file(std::string("solmod_")+std::to_string(k)+".json");
     }
 }

--- a/GEMS3K/node.h
+++ b/GEMS3K/node.h
@@ -1271,7 +1271,8 @@ protected:
     ///                         (json format): interpret the flag with_comments=on as "pretty JSON" and
     ///                                   with_comments=off as "condensed JSON"
     ///  \param brief_mode     if true, tells that do not write data items,  that contain only default values in text format
-    void  write_dbr_format_file( const std::string& dbr_file, GEMS3KGenerator::IOModes type_f, bool with_comments, bool brief_mode );
+    ///  \param checkTP        if true, check that the T-P of the current system is in the lookup table (change the given T-P interval if not and use brief_mode).
+    void  write_dbr_format_file( const std::string& dbr_file, GEMS3KGenerator::IOModes type_f, bool with_comments, bool brief_mode, bool checkTP=false );
 
 
     // Methods to perform output to vtk files

--- a/GEMS3K/node.h
+++ b/GEMS3K/node.h
@@ -55,6 +55,7 @@
 #ifndef NODE_H
 #define NODE_H
 
+#include  <map>
 // #include "allan_ipm.h"
 #include "datach_api.h"
 #include "activities.h"

--- a/GEMS3K/node_copy.cpp
+++ b/GEMS3K/node_copy.cpp
@@ -544,8 +544,8 @@ void TNode::CheckMtparam()
     P = PPa/bar_to_Pa;
     //pmp->pTPD = 2;
     node_logger->debug("CheckMtparam T: {} - {}  P: {} - {}", pmm->Tc, TK, pmm->Pc, P);
-    if( !load_thermodynamic_data || fabs( pmm->Tc - TK ) > CSD->Ttol
-            || fabs( pmm->Pc - P )  > CSD->Ptol/bar_to_Pa  )
+    if( !load_thermodynamic_data || fabs( pmm->Tc - TK ) >= CSD->Ttol
+            || fabs( pmm->Pc - P )  >= CSD->Ptol/bar_to_Pa  )
     {
         pmm->pTPD = 0;      //T, P is changed
     }

--- a/GEMS3K/node_copy.cpp
+++ b/GEMS3K/node_copy.cpp
@@ -57,8 +57,12 @@ void  TNode::read_dbr_format_file( const std::string& dbr_file, GEMS3KGenerator:
 }
 
 void  TNode::write_dbr_format_file( const std::string& dbr_file, GEMS3KGenerator::IOModes type_f,
-                                    bool with_comments, bool brief_mode )
+                                    bool with_comments, bool brief_mode, bool checkTP )
 {
+    if(checkTP && dbr_dch_api::change_TP(CSD, CNode->TK, CNode->P)) {
+        brief_mode = true;
+    }
+
 #ifdef NO_NODEARRAYLEVEL
     CNode->NodeStatusFMT = No_nodearray;
 #endif

--- a/GEMS3K/nodearray.cpp
+++ b/GEMS3K/nodearray.cpp
@@ -707,7 +707,7 @@ std::string TNodeArray::genGEMS3KInputFiles(  const std::string& filepath, Proce
         message( "Writing to disk a set of node array files from interrupted RMT task. \nPlease, wait...", ii );
         CopyWorkNodeFromArray( calcNode, ii, anNodes, NodT0 );
         auto dbr_file_name = generator.gen_dbr_file_name( 0, ii );
-        calcNode->write_dbr_format_file( generator.get_path(dbr_file_name), generator.files_mode(), with_comments, brief_mode );
+        calcNode->write_dbr_format_file( generator.get_path(dbr_file_name), generator.files_mode(), with_comments, brief_mode, true );
 
         fout_dat_lst << " \"" << dbr_file_name << "\"";
         if( !first )
@@ -720,7 +720,7 @@ std::string TNodeArray::genGEMS3KInputFiles(  const std::string& filepath, Proce
 
             CopyWorkNodeFromArray( calcNode, ii, anNodes, NodT1 );
             auto dbr2_file_name = generator.gen_dbr_file_name( 1, ii );
-            calcNode->write_dbr_format_file( generator.get_path(dbr2_file_name), generator.files_mode(), with_comments, brief_mode );
+            calcNode->write_dbr_format_file( generator.get_path(dbr2_file_name), generator.files_mode(), with_comments, brief_mode, true );
         }
     } // ii
 

--- a/GEMS3K/s_solmod.cpp
+++ b/GEMS3K/s_solmod.cpp
@@ -177,14 +177,14 @@ void TSolMod::alloc_multisite()
         {
             mn[j][s] = new double [NMoi];
             // for(long int m=0; m<NMoi; m++) {
-            //     mn[j][s][m] = -1.;
+            //     mn[j][s][m] = 0.;
             // }
 
         }
    }
    mns = new double[NSub];
    // for(j=0; j<NSub; j++) {
-   //     mns[j] = -1.;
+   //     mns[j] = 1.;
    // }
 }
 
@@ -194,22 +194,36 @@ void TSolMod::alloc_multisite()
 /// from that for the previous end member (this is an error)
 long int TSolMod::init_multisite()
 {
+    std::string deb_info;
     long int j, s, m, k=0;
     if( !NSub || !NMoi )
         return 0;   // This is not a multi-site model
 
-    solmod_logger->info("!!! phase: {}", PhaseName);
     for( s=0; s<NSub; s++)
         for( m=0; m<NMoi; m++)
             y[s][m] = 0.0;
     // copying multiplicity numbers
     for( j=0; j<NComp; j++)
         for( s=0; s<NSub; s++)
-           for( m=0; m<NMoi; m++)
-           {  // extracting multiplicity numbers
-              mn[j][s][m] = aMoiSN[k];
-              k++;
-           }
+            for( m=0; m<NMoi; m++)
+            {  // extracting multiplicity numbers
+                mn[j][s][m] = aMoiSN[k];
+                k++;
+            }
+
+    if(TSolMod::solmod_logger->should_log(spdlog::level::trace)) {
+        solmod_logger->trace("!!! phase: {}", PhaseName);
+        for( j=0; j<NComp; j++) {
+            for( s=0; s<NSub; s++) {
+                deb_info += to_string(mn[j][s], NMoi);
+                deb_info += "\n";
+            }
+            deb_info += "\n";
+        }
+        solmod_logger->trace("array of end member moiety-site multiplicity numbers [NComp={}][NSub={}][NMoi={}]:  {}",
+                            NComp, NSub, NMoi, deb_info);
+    }
+
     // calculation of total site multiplicity numbers
     double mnsj;
     for( s=0; s<NSub; s++) {
@@ -232,24 +246,12 @@ long int TSolMod::init_multisite()
             }
         }
     }
-    // debug print
-    std::string deb_info;
-    for(j=0; j<NSub; j++) {
-        deb_info += std::to_string(mns[j])+" ";
+
+    if(TSolMod::solmod_logger->should_log(spdlog::level::trace)) {
+        // debug print
+        deb_info = to_string(mns, NSub);
+        solmod_logger->trace("array of total site multiplicities: NSub = {}:  {}", NSub, deb_info);
     }
-    solmod_logger->info("array of total site multiplicities: size = {}:  {}", NSub, deb_info);
-    deb_info.clear();
-    for( j=0; j<NComp; j++) {
-        for( s=0; s<NSub; s++) {
-            for( m=0; m<NMoi; m++) {  // extracting multiplicity numbers
-                deb_info += std::to_string(mn[j][s][m])+" ";
-            }
-            deb_info += "\n";
-        }
-        deb_info += "\n";
-    }
-    solmod_logger->info("array of end member moiety-site multiplicity numbers [NComp={}][NSub={}][NMoi={}]:  {}",
-                        NComp, NSub, NMoi, deb_info);
     return 0;
 }
 

--- a/GEMS3K/s_solmod.cpp
+++ b/GEMS3K/s_solmod.cpp
@@ -176,9 +176,16 @@ void TSolMod::alloc_multisite()
         for(s=0; s<NSub; s++)
         {
             mn[j][s] = new double [NMoi];
+            // for(long int m=0; m<NMoi; m++) {
+            //     mn[j][s][m] = -1.;
+            // }
+
         }
    }
    mns = new double[NSub];
+   // for(j=0; j<NSub; j++) {
+   //     mns[j] = -1.;
+   // }
 }
 
 
@@ -191,6 +198,7 @@ long int TSolMod::init_multisite()
     if( !NSub || !NMoi )
         return 0;   // This is not a multi-site model
 
+    solmod_logger->info("!!! phase: {}", PhaseName);
     for( s=0; s<NSub; s++)
         for( m=0; m<NMoi; m++)
             y[s][m] = 0.0;
@@ -204,24 +212,44 @@ long int TSolMod::init_multisite()
            }
     // calculation of total site multiplicity numbers
     double mnsj;
-    for( s=0; s<NSub; s++)
-    {
-       for( j=0; j<NComp; j++)
-       {
-          mnsj = 0.;
-          for( m=0; m<NMoi; m++ )
-             mnsj += mn[j][s][m];     // eq 5.1-6
-          if( !j )
-             mns[s] = mnsj;  // use NormDoubleRound(mnsj, 6)?
-          else {  // comparing with mns for previous end member
-              if( fabs( mns[s] - mnsj ) > 1e-6 )  // bugfix 06.06.2011 DK
-              { // error - inconsistent multiplicity number in different end members
-                 return j; // returns the end member index
-              }
-//              mns[s] = mnsj;
-          }
-       }
+    for( s=0; s<NSub; s++) {
+        for( j=0; j<NComp; j++) {
+            mnsj = 0.;
+            for( m=0; m<NMoi; m++ ) {
+                mnsj += mn[j][s][m];     // eq 5.1-6
+            }
+            if( !j ) {
+                mns[s] = mnsj;  // use NormDoubleRound(mnsj, 6)?
+            }
+            else {  // comparing with mns for previous end member
+                if( fabs( mns[s] - mnsj ) > 1e-6 )  // bugfix 06.06.2011 DK
+                { // error - inconsistent multiplicity number in different end members
+                    solmod_logger->warn("{} error - inconsistent multiplicity number in different end members: j = {} s= {}  mns[s]= {} mnsj={}",
+                                        PhaseName, j, s, mns[s], mnsj);
+                    //return j; // returns the end member index
+                }
+                //              mns[s] = mnsj;
+            }
+        }
     }
+    // debug print
+    std::string deb_info;
+    for(j=0; j<NSub; j++) {
+        deb_info += std::to_string(mns[j])+" ";
+    }
+    solmod_logger->info("array of total site multiplicities: size = {}:  {}", NSub, deb_info);
+    deb_info.clear();
+    for( j=0; j<NComp; j++) {
+        for( s=0; s<NSub; s++) {
+            for( m=0; m<NMoi; m++) {  // extracting multiplicity numbers
+                deb_info += std::to_string(mn[j][s][m])+" ";
+            }
+            deb_info += "\n";
+        }
+        deb_info += "\n";
+    }
+    solmod_logger->info("array of end member moiety-site multiplicity numbers [NComp={}][NSub={}][NMoi={}]:  {}",
+                        NComp, NSub, NMoi, deb_info);
     return 0;
 }
 


### PR DESCRIPTION
Bugfix: skipped initialization into TSolMod arrays 'mn' and 'mns'  ( moiety-site) without any message (get undefined data)

If exporting dbr files, check that the T-P of the current system is in the lookup table (change the given T-P interval to the first point T,P if not, and use brief_mode).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added T–P clamping support for DATACH lookups when values fall outside interpolation bounds.
  * Added an option to validate and automatically adjust T–P during per-node DBR file generation (enabling brief mode when adjustment is applied).
* **Bug Fixes**
  * Improved out-of-range reporting for T–P validation in non-interpolation mode.
  * Multisite multiplicity mismatches now warn and continue (no early return).
  * Guarded debug JSON logging to avoid null dereferences.
* **Diagnostics**
  * Enhanced trace logging for multisite multiplicity calculations.
* **Chores**
  * Updated the GEMS3K version identifier/hash.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->